### PR TITLE
Implement the openpgpjs backend (desktop + mobile support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ Now in the settings you will find the following elements to configure:
 
 ![Configure plugin](img/Screenshot_02.png)
 
+## OpenPGP.js library (desktop and mobile)
+
+The **GPG Library** setting lets you choose how encryption is performed:
+
+- **CLI commands** — the default behaviour described above: encryption is delegated to the native GPG executable installed on your system. Works with the OS keychain and security keys such as YubiKey. Desktop only.
+- **openpgpjs** — encryption is performed in-app by [OpenPGP.js](https://openpgpjs.org/), with no native GPG executable required. This works on **desktop and mobile (Android/iOS)**.
+
+When `openpgpjs` is selected, the settings show:
+
+1. **Public Key (Armored)** — paste your ASCII-armored public key (used for encryption).
+2. **Private Key (Armored)** — paste your ASCII-armored private key (used for decryption, stored in the plugin's local data).
+3. **Private Key Passphrase (optional)** — leave blank to be prompted for the passphrase at decrypt time (recommended); or save it to be decrypted automatically.
+4. **Passphrase cache duration (minutes)** — how long an entered passphrase is kept in memory before being required again.
+5. **Sign when encrypting** — also sign the text with your private key.
+
+> Note: in `openpgpjs` mode the private key is stored in the plugin's local data (`data.json`). Only enable the saved passphrase if you understand that it is written to disk in plain text.
+
 ## Encrypt some text
 
 Step 1 - In a note you have, select the text you want to encrypt (For inline encryption) and open the command palette

--- a/manifest.json
+++ b/manifest.json
@@ -7,5 +7,5 @@
 	"author": "Luis Jaramillo",
 	"authorUrl": "https://www.lajg.dev",
 	"fundingUrl": "https://www.lajg.dev/donate/",
-	"isDesktopOnly": true
+	"isDesktopOnly": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.1.5",
 			"license": "MIT",
 			"dependencies": {
-				"@codemirror/language": "^6.12.3"
+				"@codemirror/language": "^6.12.3",
+				"openpgp": "^6.3.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.6.0",
@@ -1651,6 +1652,15 @@
 			"peerDependencies": {
 				"@codemirror/state": "6.5.0",
 				"@codemirror/view": "6.38.6"
+			}
+		},
+		"node_modules/openpgp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.3.0.tgz",
+			"integrity": "sha512-pLzCU8IgyKXPSO11eeharQkQ4GzOKNWhXq79pQarIRZEMt1/ssyr+MIuWBv1mNoenJLg04gvPx+fi4gcKZ4bag==",
+			"license": "LGPL-3.0+",
+			"engines": {
+				"node": ">= 18.0.0"
 			}
 		},
 		"node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"typescript": "^5.9.3"
 	},
 	"dependencies": {
-		"@codemirror/language": "^6.12.3"
+		"@codemirror/language": "^6.12.3",
+		"openpgp": "^6.3.0"
 	}
 }

--- a/src/DecryptPreviewModal.ts
+++ b/src/DecryptPreviewModal.ts
@@ -2,6 +2,8 @@ import { App, Modal, Notice, Setting } from "obsidian";
 import { GPG_INLINE_ENCRYPT_PREFIX } from "./EncryptModal";
 import { DecryptModal } from "./DecryptModal";
 import { GpgResult, gpgDecrypt } from "./gpg";
+import { base64ToUtf8, getPassphrase, setCachedPassphrase } from "./openpgp";
+import { PassphraseModal } from "./PassphraseModal";
 import GpgEncryptPlugin from "main";
 
 // Decrypt Preview modal (Works for inline and document encryption)
@@ -19,10 +21,12 @@ export class DecryptPreviewModal extends Modal {
         let encryptedMessageBase64WithoutScapeKeys = encryptedMessageBase64.substring(GPG_INLINE_ENCRYPT_PREFIX.length + 1, encryptedMessageBase64.length);
         // Assing encryptedMessageBase64WithoutScapeKeys to encryptedMessageBase64
         this.encryptedMessageBase64 = encryptedMessageBase64WithoutScapeKeys;
-        // Create a buffer from the string
-        let bufferObj = Buffer.from(encryptedMessageBase64WithoutScapeKeys, "base64");
-        // Encode the Buffer as a utf8 string
-        this.encryptedMessage = bufferObj.toString("utf8");
+        // Decode base64 to the armored message (browser-safe for openpgpjs/mobile, Buffer for native)
+        if (plugin.settings.pgpLibrary === "openpgpjs") {
+            this.encryptedMessage = base64ToUtf8(encryptedMessageBase64WithoutScapeKeys);
+        } else {
+            this.encryptedMessage = Buffer.from(encryptedMessageBase64WithoutScapeKeys, "base64").toString("utf8");
+        }
 	}
 
     // OnOpen Method
@@ -81,10 +85,31 @@ export class DecryptPreviewModal extends Modal {
             btn.setIcon("loader")
             // Disable button before encryption
             btn.setDisabled(true);
+            // For openpgpjs, obtain the passphrase (from cache/settings, or prompt the user)
+            let passphrase: string | null = null;
+            let closedForPrompt: boolean = false;
+            if (this.plugin.settings.pgpLibrary === "openpgpjs") {
+                passphrase = getPassphrase(this.plugin.settings);
+                // If no passphrase is available, close this modal and prompt for one
+                if (!passphrase) {
+                    this.close();
+                    closedForPrompt = true;
+                    passphrase = await PassphraseModal.prompt(this.app);
+                    // If the user cancelled, abort
+                    if (!passphrase) {
+                        return;
+                    }
+                }
+            }
             // Send Decrypt command
-            let decryptedTextResult: GpgResult = await gpgDecrypt(this.plugin.settings, this.encryptedMessage);
+            let decryptedTextResult: GpgResult = await gpgDecrypt(this.plugin.settings, this.encryptedMessage, passphrase);
             // Check if result contains data
             if (decryptedTextResult.result) {
+                // Cache the passphrase after a successful decrypt (openpgpjs only)
+                if (this.plugin.settings.pgpLibrary === "openpgpjs" && passphrase) {
+                    const cacheMs: number = (this.plugin.settings.pgpPassphraseCacheMinutes || 5) * 60 * 1000;
+                    setCachedPassphrase(passphrase, cacheMs);
+                }
                 // Extra info in decrypt process
                 let extraInfo: string = "";
                 // In case of any error happend
@@ -94,18 +119,26 @@ export class DecryptPreviewModal extends Modal {
                 }
                 // Open a new decrypt modal with plain text
                 new DecryptModal(this.app, decryptedTextResult.result.toString().trim(), extraInfo, this.plugin, this.from, this.to).open();
-                // Close this modal
-                this.close();
+                // Close this modal (unless it was already closed for the passphrase prompt)
+                if (!closedForPrompt) {
+                    this.close();
+                }
             }
             // In case of any error happend
             else if (decryptedTextResult.error) {
                 // Show the error message
                 new Notice(decryptedTextResult.error.message);
+                // Reopen the preview if it was closed for the passphrase prompt
+                if (closedForPrompt) {
+                    this.open();
+                }
             }
-            // Enable button after encryption
-            btn.setDisabled(false);
-            // Change loader icon by text
-            btn.setButtonText(buttonName)
+            // Enable button after encryption (only if the modal is still open)
+            if (!closedForPrompt) {
+                btn.setDisabled(false);
+                // Change loader icon by text
+                btn.setButtonText(buttonName)
+            }
         }));
     }
 

--- a/src/EncryptModal.ts
+++ b/src/EncryptModal.ts
@@ -1,6 +1,7 @@
 import { GpgResult, getListPublicKey, gpgEncrypt } from "src/gpg";
 import { App, Editor, MarkdownView, Modal, Notice, Setting } from "obsidian";
 import GpgEncryptPlugin from 'main';
+import { utf8ToBase64 } from "./openpgp";
 
 // Enum to identify encrypt modal mode
 export enum EncryptModalMode {
@@ -54,6 +55,32 @@ export class EncryptModal extends Modal {
             new Notice('❌ Open a file to encrypt');
             // Close this modal
             this.close();
+        }
+        // For openpgpjs, use the single configured key with a simplified UI
+        if (this.plugin.settings.pgpLibrary === "openpgpjs") {
+            // Require a configured public key
+            if (!this.plugin.settings.pgpPublicKeyArmored || this.plugin.settings.pgpPublicKeyArmored.trim() === "") {
+                contentEl.createEl("p", { text: "❌ No public key configured. Go to plugin settings and paste your GPG public key." });
+                return;
+            }
+            // Show which key will be used
+            let openpgpKeys = await getListPublicKey(this.plugin.settings);
+            if (openpgpKeys.length > 0) {
+                contentEl.createEl("p", { text: "Encrypting with key: " + openpgpKeys[0].userID + " (" + openpgpKeys[0].keyID + ")" });
+            }
+            // The configured key is always used as recipient
+            this.listPublicKeyToEncrypt = ["configured-key"];
+            // Note and button text depending on sign setting
+            let openpgpSignNote = this.plugin.settings.pgpSignPublicKeyId !== "0" ? "Text will also be signed with your private key." : "";
+            let openpgpButtonName = this.plugin.settings.pgpSignPublicKeyId !== "0" ? "Sign & Encrypt" : "Encrypt";
+            new Setting(contentEl).setDesc(openpgpSignNote).addButton((btn) => btn.setButtonText(openpgpButtonName).setCta().onClick(async() => {
+                btn.setIcon("loader");
+                btn.setDisabled(true);
+                await this.EncryptText();
+                btn.setDisabled(false);
+                btn.setButtonText(openpgpButtonName);
+            }));
+            return;
         }
         // Help text is created to select GPG keys
         contentEl.createEl("p", { text: "Select which Public GPG key(s) you want to be able to decrypt the text:" });
@@ -137,7 +164,7 @@ export class EncryptModal extends Modal {
             // In case of no error happend
             else {
                 // Replace encrypted text in selection
-                this.editor.replaceSelection(this.BufferToSecretBase64(encryptedTextResult.result!));
+                this.editor.replaceSelection(this.ToSecretBase64(encryptedTextResult.result!));
                 // Close this modal
                 this.close();
             }
@@ -149,7 +176,7 @@ export class EncryptModal extends Modal {
             // Check if result contains data
             if (encryptedTextResult.result) {
                 // Replace encrypted text in selection
-                this.editor.setValue(this.BufferToSecretBase64(encryptedTextResult.result));
+                this.editor.setValue(this.ToSecretBase64(encryptedTextResult.result));
                 // Close this modal
                 this.close();
             }
@@ -161,9 +188,11 @@ export class EncryptModal extends Modal {
         }
     }
 
-    // Convert Buffer to text in Base64 with some scape characters to be identify in LivePreview
-    private BufferToSecretBase64(bufferEncrypted: Buffer): string {
-        // Return buffer converted in Base64 with some scape characters to be identify in LivePreview
-        return "`" + GPG_INLINE_ENCRYPT_PREFIX + " " + bufferEncrypted.toString('base64') + "`";
+    // Convert the encrypted result to Base64 with some scape characters to be identify in LivePreview
+    private ToSecretBase64(encrypted: Buffer | string): string {
+        // Native GPG returns a Buffer; openpgpjs returns an armored string (encode browser-safe)
+        const base64: string = typeof encrypted === "string" ? utf8ToBase64(encrypted) : encrypted.toString('base64');
+        // Return encoded text with some scape characters to be identify in LivePreview
+        return "`" + GPG_INLINE_ENCRYPT_PREFIX + " " + base64 + "`";
     }
 }

--- a/src/PassphraseModal.ts
+++ b/src/PassphraseModal.ts
@@ -1,0 +1,62 @@
+import { App, Modal, Setting } from "obsidian";
+
+// Modal that prompts for the private key passphrase (mobile has no pinentry/gpg-agent)
+export class PassphraseModal extends Modal {
+
+    private passphrase = "";
+    private submitted = false;
+    private resolve!: (value: string | null) => void;
+
+    constructor(app: App) {
+        super(app);
+    }
+
+    // Open the modal and resolve with the entered passphrase, or null if cancelled
+    static prompt(app: App): Promise<string | null> {
+        return new Promise((resolve) => {
+            const modal = new PassphraseModal(app);
+            modal.resolve = resolve;
+            modal.open();
+        });
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.createEl("h2", { text: "🔑 Enter Passphrase" });
+        contentEl.createEl("p", { text: "Enter your GPG private key passphrase to decrypt." });
+        new Setting(contentEl).setName("Passphrase").addText((text) => {
+            text.setPlaceholder("Enter passphrase...");
+            text.inputEl.type = "password";
+            text.inputEl.style.width = "100%";
+            text.inputEl.addEventListener("keydown", (e: KeyboardEvent) => {
+                if (e.key === "Enter") {
+                    this.submit();
+                }
+            });
+            text.onChange((value: string) => {
+                this.passphrase = value;
+            });
+            setTimeout(() => text.inputEl.focus(), 50);
+        });
+        new Setting(contentEl)
+            .addButton((btn) => btn.setButtonText("Unlock").setCta().onClick(() => this.submit()))
+            .addButton((btn) => btn.setButtonText("Cancel").onClick(() => {
+                this.resolve(null);
+                this.close();
+            }));
+    }
+
+    private submit() {
+        this.submitted = true;
+        this.resolve(this.passphrase);
+        this.close();
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+        if (!this.submitted && this.resolve) {
+            this.resolve(null);
+        }
+    }
+}

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -10,7 +10,12 @@ export interface GpgEncryptSettings {
     pgpAditionalCommands: boolean,
     pgpAditionalCommandsBefore: string,
     pgpAditionalCommandsAfter: string,
-    pgpAditionalCommandsConsole: boolean
+    pgpAditionalCommandsConsole: boolean,
+    // OpenPGP.js library settings (used when pgpLibrary === "openpgpjs")
+    pgpPublicKeyArmored: string,
+    pgpPrivateKeyArmored: string,
+    pgpPassphrase: string,
+    pgpPassphraseCacheMinutes: number
 }
 
 // Default settings values
@@ -23,7 +28,12 @@ const DEFAULT_SETTINGS: GpgEncryptSettings = {
     pgpAditionalCommands: false,
     pgpAditionalCommandsBefore: "",
     pgpAditionalCommandsAfter: "",
-    pgpAditionalCommandsConsole: false
+    pgpAditionalCommandsConsole: false,
+    // OpenPGP.js library settings
+    pgpPublicKeyArmored: "",
+    pgpPrivateKeyArmored: "",
+    pgpPassphrase: "",
+    pgpPassphraseCacheMinutes: 5
 }
 
 // Settings class
@@ -50,6 +60,10 @@ export class Settings {
 
 // Get Default Exec Path in base on platform name
 function getDefaultExecPath(): string {
+    // On mobile there is no Node process; return empty (native GPG is unavailable there)
+    if (typeof process === "undefined" || !process.platform) {
+        return "";
+    }
     // Check platform name
     switch (process.platform) {
         // In case of Windows OS

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -2,7 +2,6 @@ import spawnGPG, { GpgResult, getListPublicKey } from 'src/gpg';
 import { App, DropdownComponent, PluginSettingTab, Setting } from 'obsidian';
 import GpgEncryptPlugin from 'main';
 import { Settings } from './Settings';
-let fs = require('fs');
 
 // Enum of types of GPG executable path status
 enum GpgExecPathStatus {
@@ -34,8 +33,11 @@ export class GpgSettingsTab extends PluginSettingTab {
 	private gpgAditionalCommandsWarning: HTMLDivElement;
 	private gpgPublicKeysList: Setting;
 	private gpgSignKeyId: Setting;
+	private gpgSignText: Setting;
 	private gpgAlwaysTrust: Setting;
 	private gpgLibrary: Setting;
+	private openpgpSettingsEl: HTMLDivElement;
+	private openpgpKeyInfoEl: HTMLDivElement;
     // Display function in settings tabs
 	display(): void {
 		// Container Element
@@ -63,6 +65,10 @@ export class GpgSettingsTab extends PluginSettingTab {
 				})
 			});
 		// ---------- GPG Library ----------
+
+		// ---------- OpenPGP.js settings (populated by RefreshLibrary) ----------
+		this.openpgpSettingsEl = containerEl.createDiv();
+		// ---------- OpenPGP.js settings ----------
 
 		// ---------- GPG executable setting ----------
 		this.gpgExecPath = new Setting(containerEl)
@@ -103,7 +109,7 @@ export class GpgSettingsTab extends PluginSettingTab {
 		// ---------- Always Trust ----------
 
 		// ---------- Sign text ----------
-		new Setting(containerEl)
+		this.gpgSignText = new Setting(containerEl)
 			.setName("Sign encrypted text")
 			.setDesc("Sign the encrypted text with GPG")
 			.addToggle((toggle) => {
@@ -158,6 +164,8 @@ export class GpgSettingsTab extends PluginSettingTab {
 		if (this.plugin.settings.pgpLibrary == "openpgpjs")
 			// Abort the process
 			return;
+		// Lazy require so the settings tab still loads on mobile, where fs is absent
+		const fs = require('fs');
 		// Set settig variable pgpExecPath with new value
 		this.plugin.settings.pgpExecPath = value;
 		// Save settings with change
@@ -423,15 +431,21 @@ export class GpgSettingsTab extends PluginSettingTab {
 			this.gpgExecPath.settingEl.hide();
 			this.gpgPublicKeysList.settingEl.hide();
 			this.gpgSignKeyId.settingEl.hide();
+			this.gpgSignText.settingEl.hide();
 			this.gpgAlwaysTrust.settingEl.hide();
+			// Render the OpenPGP.js settings (armored keys, passphrase, cache)
+			this.renderOpenpgpSettings();
 		}
 		// Check if library is not openpgpjs
 		else
 		{
+			// Clear the OpenPGP.js settings
+			this.openpgpSettingsEl.empty();
 			// And show the aditional commands settings
 			this.gpgAditionalCommands.settingEl.show();
 			this.gpgExecPath.settingEl.show();
 			this.gpgPublicKeysList.settingEl.show();
+			this.gpgSignText.settingEl.show();
 			this.gpgAlwaysTrust.settingEl.show();
 			if (this.plugin.settings.pgpSignPublicKeyId != "0")
 				this.gpgSignKeyId.settingEl.show();
@@ -442,5 +456,104 @@ export class GpgSettingsTab extends PluginSettingTab {
 
 		// Call method to show/hide aditional commands
 		this.RefreshAditionalCommands(this.plugin.settings.pgpAditionalCommands);
+	}
+
+	// Render the OpenPGP.js settings (armored keys, passphrase, cache, key info)
+	private renderOpenpgpSettings() {
+		// Clear previous content
+		const el = this.openpgpSettingsEl;
+		el.empty();
+
+		// ---------- Public Key (Armored) ----------
+		new Setting(el)
+			.setName("Public Key (Armored)")
+			.setDesc("Paste your ASCII-armored GPG public key here. Used for encryption.");
+		const publicKeyArea = el.createEl("textarea", { cls: "gpg-key-textarea" });
+		publicKeyArea.placeholder = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----";
+		publicKeyArea.value = this.plugin.settings.pgpPublicKeyArmored || "";
+		publicKeyArea.rows = 6;
+		publicKeyArea.addEventListener("change", async () => {
+			this.plugin.settings.pgpPublicKeyArmored = publicKeyArea.value;
+			await new Settings(this.plugin).saveSettings();
+			this.refreshKeyInfo();
+		});
+
+		// ---------- Private Key (Armored) ----------
+		new Setting(el)
+			.setName("Private Key (Armored)")
+			.setDesc("Paste your ASCII-armored GPG private key here. Used for decryption. Stored locally in plugin data.");
+		const privateKeyArea = el.createEl("textarea", { cls: "gpg-key-textarea" });
+		privateKeyArea.placeholder = "-----BEGIN PGP PRIVATE KEY BLOCK-----\n...\n-----END PGP PRIVATE KEY BLOCK-----";
+		privateKeyArea.value = this.plugin.settings.pgpPrivateKeyArmored || "";
+		privateKeyArea.rows = 6;
+		privateKeyArea.addEventListener("change", async () => {
+			this.plugin.settings.pgpPrivateKeyArmored = privateKeyArea.value;
+			await new Settings(this.plugin).saveSettings();
+		});
+
+		// ---------- Passphrase (optional) ----------
+		new Setting(el)
+			.setName("Private Key Passphrase (optional)")
+			.setDesc("Save passphrase to disk for auto-decrypt. Leave blank to be prompted each time (recommended).")
+			.addText((text) => {
+				text.setPlaceholder("leave blank to prompt")
+					.setValue(this.plugin.settings.pgpPassphrase || "")
+					.onChange(async (value: string) => {
+						this.plugin.settings.pgpPassphrase = value;
+						await new Settings(this.plugin).saveSettings();
+					});
+				text.inputEl.type = "password";
+			});
+
+		// ---------- Passphrase cache duration ----------
+		new Setting(el)
+			.setName("Passphrase cache duration (minutes)")
+			.setDesc("How long to remember the passphrase in memory after entering it. Set to 0 to prompt every time.")
+			.addText((text) => text
+				.setPlaceholder("5")
+				.setValue(String(this.plugin.settings.pgpPassphraseCacheMinutes ?? 5))
+				.onChange(async (value: string) => {
+					this.plugin.settings.pgpPassphraseCacheMinutes = parseInt(value) || 0;
+					await new Settings(this.plugin).saveSettings();
+				}));
+
+		// ---------- Key info ----------
+		this.openpgpKeyInfoEl = el.createDiv();
+		this.refreshKeyInfo();
+
+		// ---------- Sign when encrypting ----------
+		new Setting(el)
+			.setName("Sign when encrypting")
+			.setDesc("Sign the encrypted text with your private key")
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.pgpSignPublicKeyId !== "0");
+				toggle.onChange(async (value: boolean) => {
+					this.plugin.settings.pgpSignPublicKeyId = value ? "sign" : "0";
+					await new Settings(this.plugin).saveSettings();
+				});
+			});
+	}
+
+	// Refresh the OpenPGP.js public key info readout
+	private async refreshKeyInfo() {
+		// Nothing to do if the info element is not present
+		if (!this.openpgpKeyInfoEl) return;
+		this.openpgpKeyInfoEl.empty();
+		// Only show info when a public key is configured
+		if (!this.plugin.settings.pgpPublicKeyArmored || this.plugin.settings.pgpPublicKeyArmored.trim() === "") {
+			return;
+		}
+		try {
+			const keys = await getListPublicKey(this.plugin.settings);
+			if (keys.length > 0) {
+				const infoEl = this.openpgpKeyInfoEl.createDiv();
+				infoEl.className = "text-color-green";
+				infoEl.setText("✅ Public key loaded: " + keys.map((k) => k.userID + " (" + k.keyID + ")").join(", "));
+			}
+		} catch (ex: any) {
+			const errEl = this.openpgpKeyInfoEl.createDiv();
+			errEl.className = "text-color-red";
+			errEl.setText("❌ Error reading public key: " + ex.message);
+		}
 	}
 }

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -1,12 +1,12 @@
-import { spawn } from "child_process";
 import { GpgEncryptSettings } from "./Settings";
+import * as openpgpBackend from "./openpgp";
 
 // Default and Global Args
 const globalArgs: string[] = ["--batch"];
 
 // Object that is returned when spawnGPG method is called
 export interface GpgResult {
-    result?: Buffer;
+    result?: Buffer | string;
     error?: Error;
 }
 
@@ -55,6 +55,8 @@ export default function spawnGPG(settings: GpgEncryptSettings,  input: string | 
         if (settings.pgpAditionalCommandsConsole) {
           console.log(command);
         }
+        // Lazy require so the module still loads on mobile, where child_process is absent
+        const { spawn } = require("child_process");
         const gpg = spawn(command, { shell: true });
     
         gpg.stdout.on("data", (buf: Buffer) => {
@@ -105,8 +107,18 @@ export default function spawnGPG(settings: GpgEncryptSettings,  input: string | 
     });
 }
 
-// Get list of all Public Key availables
+// Get list of all Public Key availables (routes to the selected library)
 export async function getListPublicKey(settings: GpgEncryptSettings): Promise<{ keyID: string; userID: string }[]> {
+  // When openpgpjs is selected, use the OpenPGP.js backend
+  if (settings.pgpLibrary === "openpgpjs") {
+    return openpgpBackend.getListPublicKey(settings);
+  }
+  // Otherwise use the native GPG executable
+  return nativeGetListPublicKey(settings);
+}
+
+// Get list of all Public Key availables using the native GPG executable
+async function nativeGetListPublicKey(settings: GpgEncryptSettings): Promise<{ keyID: string; userID: string }[]> {
   // Build the executable and args
   const gpgResult: GpgResult  = await spawnGPG(settings, null, ["--logger-fd", "1", "--list-public-keys", "--with-colons"]);
   // Check if result are null
@@ -141,8 +153,18 @@ export async function getListPublicKey(settings: GpgEncryptSettings): Promise<{ 
   return keys;
 }
 
-// Function to encrypt a plainText with a list of GPG public keys ID
-export async function gpgEncrypt(settings: GpgEncryptSettings, plainText:string, publicKeyIds: string[], signPublicKeyId: string): Promise<GpgResult> {
+// Function to encrypt a plainText with a list of GPG public keys ID (routes to the selected library)
+export async function gpgEncrypt(settings: GpgEncryptSettings, plainText:string, publicKeyIds: string[], signPublicKeyId: string, passphrase?: string | null): Promise<GpgResult> {
+  // When openpgpjs is selected, use the OpenPGP.js backend
+  if (settings.pgpLibrary === "openpgpjs") {
+    return openpgpBackend.gpgEncrypt(settings, plainText, publicKeyIds, signPublicKeyId, passphrase);
+  }
+  // Otherwise use the native GPG executable
+  return nativeGpgEncrypt(settings, plainText, publicKeyIds, signPublicKeyId);
+}
+
+// Function to encrypt a plainText using the native GPG executable
+async function nativeGpgEncrypt(settings: GpgEncryptSettings, plainText:string, publicKeyIds: string[], signPublicKeyId: string): Promise<GpgResult> {
   // Check if at least one public key is selected
   if (publicKeyIds.length <= 0) {
     // And return with error message
@@ -186,8 +208,18 @@ export async function gpgEncrypt(settings: GpgEncryptSettings, plainText:string,
 }
 
 
-// Function to decrypt an encrypted text with a private key
-export async function gpgDecrypt(settings: GpgEncryptSettings, encryptedText:string): Promise<GpgResult> {
+// Function to decrypt an encrypted text with a private key (routes to the selected library)
+export async function gpgDecrypt(settings: GpgEncryptSettings, encryptedText:string, passphrase?: string | null): Promise<GpgResult> {
+  // When openpgpjs is selected, use the OpenPGP.js backend
+  if (settings.pgpLibrary === "openpgpjs") {
+    return openpgpBackend.gpgDecrypt(settings, encryptedText, passphrase);
+  }
+  // Otherwise use the native GPG executable
+  return nativeGpgDecrypt(settings, encryptedText);
+}
+
+// Function to decrypt an encrypted text using the native GPG executable
+async function nativeGpgDecrypt(settings: GpgEncryptSettings, encryptedText:string): Promise<GpgResult> {
   // List of Args before publicKeyIds
   let args: string[] = ["--decrypt"].concat(AditionalArgs(settings));
   // Build the executable and args

--- a/src/openpgp.ts
+++ b/src/openpgp.ts
@@ -1,0 +1,146 @@
+import { readKey, readPrivateKey, decryptKey, createMessage, encrypt, readMessage, decrypt } from "openpgp";
+import type { EncryptOptions, DecryptOptions } from "openpgp";
+import { GpgEncryptSettings } from "./Settings";
+import type { GpgResult } from "./gpg";
+
+// In-memory passphrase cache (never persisted)
+let cachedPassphrase: string | null = null;
+let cacheExpiry = 0;
+
+// Store a passphrase in memory for the given time-to-live (milliseconds)
+export function setCachedPassphrase(passphrase: string, ttlMs: number): void {
+  cachedPassphrase = passphrase;
+  cacheExpiry = Date.now() + ttlMs;
+}
+
+// Get the cached passphrase if it has not expired
+export function getCachedPassphrase(): string | null {
+  if (cachedPassphrase && Date.now() < cacheExpiry) {
+    return cachedPassphrase;
+  }
+  cachedPassphrase = null;
+  cacheExpiry = 0;
+  return null;
+}
+
+// Resolve a passphrase from the cache or from the persisted setting (if any)
+export function getPassphrase(settings: GpgEncryptSettings): string | null {
+  const cached = getCachedPassphrase();
+  if (cached) return cached;
+  if (settings.pgpPassphrase && settings.pgpPassphrase.trim() !== "") {
+    return settings.pgpPassphrase;
+  }
+  return null;
+}
+
+// Browser-safe base64 helpers (Buffer is not available on mobile)
+export function utf8ToBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export function base64ToUtf8(b64: string): string {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+// Get the list of public keys from the armored public key in settings
+export async function getListPublicKey(settings: GpgEncryptSettings): Promise<{ keyID: string; userID: string }[]> {
+  try {
+    if (!settings.pgpPublicKeyArmored || settings.pgpPublicKeyArmored.trim() === "") {
+      return [];
+    }
+    const publicKey = await readKey({ armoredKey: settings.pgpPublicKeyArmored });
+    const keyID = publicKey.getKeyID().toHex().toUpperCase();
+    const keys: { keyID: string; userID: string }[] = [];
+    for (const userID of publicKey.getUserIDs()) {
+      keys.push({ keyID, userID });
+    }
+    return keys;
+  } catch (ex) {
+    console.error("Error reading public key:", ex);
+    return [];
+  }
+}
+
+// Read and (if needed) decrypt the private key from settings
+async function decryptPrivateKey(settings: GpgEncryptSettings, passphrase: string | null) {
+  let privateKey = await readPrivateKey({ armoredKey: settings.pgpPrivateKeyArmored });
+  if (passphrase && passphrase.trim() !== "") {
+    privateKey = await decryptKey({ privateKey, passphrase });
+  }
+  return privateKey;
+}
+
+// Encrypt plainText with the configured public key, optionally signing it
+export async function gpgEncrypt(settings: GpgEncryptSettings, plainText: string, publicKeyIds: string[], signPublicKeyId: string, passphrase?: string | null): Promise<GpgResult> {
+  try {
+    if (publicKeyIds.length <= 0) {
+      return { result: undefined, error: new Error("❌ Select at least one key") };
+    }
+    if (!settings.pgpPublicKeyArmored || settings.pgpPublicKeyArmored.trim() === "") {
+      return { result: undefined, error: new Error("❌ No public key configured.") };
+    }
+    const publicKey = await readKey({ armoredKey: settings.pgpPublicKeyArmored });
+    const encryptOptions: EncryptOptions & { format: "armored" } = {
+      message: await createMessage({ text: plainText }),
+      encryptionKeys: publicKey,
+      format: "armored"
+    };
+    if (signPublicKeyId !== "0" && settings.pgpPrivateKeyArmored && settings.pgpPrivateKeyArmored.trim() !== "") {
+      const pp = passphrase != null ? passphrase : getPassphrase(settings);
+      encryptOptions.signingKeys = await decryptPrivateKey(settings, pp);
+    }
+    const encrypted = await encrypt(encryptOptions) as string;
+    return { result: encrypted, error: undefined };
+  } catch (ex: any) {
+    return { result: undefined, error: new Error("❌ Encryption failed: " + (ex.message || ex)) };
+  }
+}
+
+// Decrypt an armored message with the configured private key
+export async function gpgDecrypt(settings: GpgEncryptSettings, encryptedText: string, passphrase?: string | null): Promise<GpgResult> {
+  try {
+    if (!settings.pgpPrivateKeyArmored || settings.pgpPrivateKeyArmored.trim() === "") {
+      return { result: undefined, error: new Error("❌ No private key configured.") };
+    }
+    const pp = passphrase != null ? passphrase : getPassphrase(settings);
+    const privateKey = await decryptPrivateKey(settings, pp);
+    const message = await readMessage({ armoredMessage: encryptedText });
+    const decryptOptions: DecryptOptions = {
+      message,
+      decryptionKeys: privateKey
+    };
+    // Add the public key for signature verification when available
+    if (settings.pgpPublicKeyArmored && settings.pgpPublicKeyArmored.trim() !== "") {
+      try {
+        decryptOptions.verificationKeys = await readKey({ armoredKey: settings.pgpPublicKeyArmored });
+      } catch (e) {
+        // Ignore verification key errors; decryption can still proceed
+      }
+    }
+    const decrypted = await decrypt(decryptOptions);
+    const plainText = decrypted.data as unknown as string;
+    // Surface signature status as non-fatal extra info (matches native convention)
+    let extraInfo = "";
+    if (decrypted.signatures && decrypted.signatures.length > 0) {
+      try {
+        await decrypted.signatures[0].verified;
+        extraInfo = "✅ Signature verified";
+      } catch (e) {
+        extraInfo = "⚠️ Signature could not be verified";
+      }
+    }
+    return { result: plainText, error: extraInfo ? new Error(extraInfo) : undefined };
+  } catch (ex: any) {
+    return { result: undefined, error: new Error("❌ Decryption failed: " + (ex.message || ex)) };
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -45,3 +45,8 @@
     padding: 20px;
     font-size: 0.7em;
 }
+.gpg-key-textarea {
+    width: 100%;
+    font-family: monospace;
+    font-size: 11px;
+}


### PR DESCRIPTION
## Summary
The `pgpLibrary` setting with its `openpgpjs` option already exists in 1.1.5,
but selecting it hid the native settings without providing an implementation.
This PR fills in that backend so "openpgpjs" performs encryption/decryption
in-app via OpenPGP.js (v6.3.0) — no native `gpg` binary required — which makes
the plugin work on **mobile (Android/iOS)** as well as desktop.

The native **CLI commands** path is completely unchanged and stays the default
for OS-keychain / YubiKey users. This is purely additive.

## What changed
- `src/openpgp.ts` (new): OpenPGP.js `getListPublicKey`/`gpgEncrypt`/`gpgDecrypt`,
  an in-memory passphrase cache, and browser-safe base64 helpers.
- `src/PassphraseModal.ts` (new): prompts for the private-key passphrase
  (mobile has no pinentry/gpg-agent).
- `src/gpg.ts`: the three crypto functions dispatch on `settings.pgpLibrary`;
  `child_process` is now required lazily so the module can load on mobile.
- `src/Settings.ts`: adds `pgpPublicKeyArmored`, `pgpPrivateKeyArmored`,
  `pgpPassphrase`, `pgpPassphraseCacheMinutes`; guards `process.platform`.
- `src/SettingsTab.ts`: renders the armored-key / passphrase / cache UI in the
  openpgpjs branch; `fs` required lazily; hides the native sign toggle in
  openpgpjs mode.
- `src/EncryptModal.ts` / `src/DecryptPreviewModal.ts`: openpgpjs branches
  (single configured key, passphrase prompt + cache, browser-safe base64).
- `manifest.json`: `isDesktopOnly: false`. `styles.css`: `.gpg-key-textarea`.
  `README.md`: documents the option.

The base64 wire format is identical between backends, so blocks are
interchangeable between native gpg and OpenPGP.js for the same key.

## Notes for the maintainer
- Version left at 1.1.5 — happy to bump if you prefer.
- In openpgpjs mode the private key is stored in plugin `data.json`; the README
  flags the saved-passphrase tradeoff and prehaps this feature should NOT be implemented??

## Test plan
- [x] `npm run build` passes (tsc + esbuild).
- [x] Confirmed no Node builtins are required at module load (mobile-safe);
      `child_process`/`fs` are lazy.
- [x] OpenPGP.js roundtrip on a throwaway key: encrypt+sign → decrypt → signature verified.
- [x] Native "CLI commands" path still works on desktop (please verify in your environment).